### PR TITLE
Issue 41: Update license headers

### DIFF
--- a/examples/ifcreate.c
+++ b/examples/ifcreate.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Marie Helene Kvello-Aune
+ * Copyright (c) 2016-2017, Marie Helene Kvello-Aune
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/examples/ifdestroy.c
+++ b/examples/ifdestroy.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Marie Helene Kvello-Aune
+ * Copyright (c) 2016-2017, Marie Helene Kvello-Aune
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/examples/setdescription.c
+++ b/examples/setdescription.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Marie Helene Kvello-Aune
+ * Copyright (c) 2016-2017, Marie Helene Kvello-Aune
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/examples/setmtu.c
+++ b/examples/setmtu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Marie Helene Kvello-Aune
+ * Copyright (c) 2016-2017, Marie Helene Kvello-Aune
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/libifconfig.c
+++ b/src/libifconfig.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1983, 1993
  *  The Regents of the University of California.  All rights reserved.
- * Copyright (c) 2016, Marie Helene Kvello-Aune.  All rights reserved.
+ * Copyright (c) 2016-2017, Marie Helene Kvello-Aune.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -11,7 +11,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *

--- a/src/libifconfig.h
+++ b/src/libifconfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Marie Helene Kvello-Aune
+ * Copyright (c) 2016-2017, Marie Helene Kvello-Aune
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/libifconfig_internal.c
+++ b/src/libifconfig_internal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Marie Helene Kvello-Aune
+ * Copyright (c) 2016-2017, Marie Helene Kvello-Aune
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,

--- a/src/libifconfig_internal.h
+++ b/src/libifconfig_internal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Marie Helene Kvello-Aune
+ * Copyright (c) 2016-2017, Marie Helene Kvello-Aune
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification,


### PR DESCRIPTION
The ifconfig source has received a semantic update to the license headers of ifconfig, making the 3-clause licenses third point be numbered 3 and not 4. This should allow libifconfig to consolidate licenses.

While here, update copyright year.
Resolves issue #41