### PR TITLE
Minor fixes to style(9) compliance and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@
 
 # Stage stuff
 stage/**
-
+examples/.depend.*
 # local dev envorinment stuff
 .vscode/**
 **/.vscode/**

--- a/src/libifconfig.h
+++ b/src/libifconfig.h
@@ -37,7 +37,7 @@ typedef enum {
  * pointer to it for library use.
  */
 struct ifconfig_handle;
-typedef struct ifconfig_handle   ifconfig_handle_t;
+typedef struct ifconfig_handle ifconfig_handle_t;
 
 struct ifconfig_capabilities {
 	/** Current capabilities (ifconfig prints this as 'options')*/


### PR DESCRIPTION
Fixed style(9) violation in libifconfig.h
Added some example directory post-build '.depend.' files to .gitignore.