### PR TITLE
Some fixes for applying libifconfig repo to FreeBSD base.

### DIFF
--- a/Makefile.ci
+++ b/Makefile.ci
@@ -7,6 +7,7 @@ createfreebsdtree:
 	cp src/* stage/freebsdsrc/lib/libifconfig/
 	cp Makefile.base stage/freebsdsrc/lib/libifconfig/Makefile
 	cp examples/* stage/freebsdsrc/examples/libifconfig/
+	rm stage/freebsdsrc/examples/libifconfig/Makefile
 prepbuildinbase:
 	svnlite up ~/data/fbsdhead
 	./tools/cptofbsdsrc.sh ./ ~/data/fbsdhead


### PR DESCRIPTION
Makefile.ci: Updated to remove Makefile from examples directory.
This is because the Makefile that currently exists is for standalone builds.

tools/cptofbsdsrc.sh:
- Now removes Makefile from example directory
- Now only generates patches if a third argument is provided, which is where patches will be stored.
- Now generates a separate patch file for the examples directory

A makefile for in-tree builds of the example files would be counter-productive
to the intention of marking libifconfig as a private library in the FreeBSD tree,
and will not be made until libifconfig is no longe marked as private.